### PR TITLE
Minor fixes so the plugin could be used in future versions of UE4

### DIFF
--- a/Source/CoverGenerator/CoverGenerator.Build.cs
+++ b/Source/CoverGenerator/CoverGenerator.Build.cs
@@ -4,7 +4,7 @@ using UnrealBuildTool;
 
 public class CoverGenerator : ModuleRules
 {
-	public CoverGenerator(TargetInfo Target)
+	public CoverGenerator(ReadOnlyTargetRules Target):base(Target)
 	{
 		
 		PublicIncludePaths.AddRange(

--- a/Source/CoverGenerator/Public/CoverGenerator.h
+++ b/Source/CoverGenerator/Public/CoverGenerator.h
@@ -56,7 +56,7 @@ struct FCoverPointOctreeSemantics
 typedef TOctree<FCoverPointOctreeElement, FCoverPointOctreeSemantics> FCoverPointOctree;
 
 UCLASS()
-class ACoverGenerator : public AActor
+class COVERGENERATOR_API ACoverGenerator : public AActor
 {
 	GENERATED_UCLASS_BODY()
 

--- a/Source/CoverGenerator/Public/CoverGeneratorModule.h
+++ b/Source/CoverGenerator/Public/CoverGeneratorModule.h
@@ -4,7 +4,7 @@
 
 #include "ModuleManager.h"
 
-class FCoverGeneratorModule : public IModuleInterface
+class COVERGENERATOR_API FCoverGeneratorModule : public IModuleInterface
 {
 public:
 

--- a/Source/CoverGenerator/Public/CoverPoint.h
+++ b/Source/CoverGenerator/Public/CoverPoint.h
@@ -9,7 +9,7 @@
  * 
  */
 UCLASS(BlueprintType, Blueprintable)
-class UCoverPoint : public UObject
+class COVERGENERATOR_API UCoverPoint : public UObject
 {
 	GENERATED_BODY()	
 	


### PR DESCRIPTION
I use this plugin within both Blueprint and C++ programming environment. Although it works splendidly with Blueprint, the plugin was not usable  with C++. More precisely, I need to reference UCoverPoint objects in my project for AI, but the project did not compile. I then added a small, yet important fix to make this awesome plugin more extensible! Thanks for making this plugin free!