### PR TITLE
Async Cover Generation

### DIFF
--- a/Source/CoverGenerator/Private/GenerateCoversAsync.cpp
+++ b/Source/CoverGenerator/Private/GenerateCoversAsync.cpp
@@ -1,0 +1,25 @@
+// Copyright (2017) Ivan Stummer - All rights reserved.
+
+#include "CoverGeneratorPrivatePCH.h"
+#include "GenerateCoversAsync.h"
+#include "CoverGenerator.h"
+
+
+void FGenerateCoversAsyncTask::DoWork()
+{
+	if (!CoverGenerator) return;
+
+	// signal of start processing
+	CoverGenerator->bIsRefreshing = true;
+
+	CoverGenerator->AnalizeMeshData(NavMeshGeometry);
+
+	// signal of end processing
+	CoverGenerator->bIsRefreshed = true;
+	CoverGenerator->bIsRefreshing = false;
+
+	GLog->Log("--------------------------------------------------------------------");
+	GLog->Log("End of cover generation async");
+	GLog->Log("--------------------------------------------------------------------");
+}
+

--- a/Source/CoverGenerator/Public/CoverGenerator.h
+++ b/Source/CoverGenerator/Public/CoverGenerator.h
@@ -10,7 +10,10 @@
 #include "AI/Navigation/NavAgentInterface.h"
 #include "AI/Navigation/RecastNavMesh.h"
 #include "CoverPoint.h" 
+#include "GenerateCoversAsync.h"
+
 #include "CoverGenerator.generated.h"
+
 
 struct FCoverPointOctreeElement
 {
@@ -224,7 +227,10 @@ public:
 
 	FVector Get2DPerpVector(const FVector& v1) const;
 
-	void GenerateCovers(bool ForceRegeneration = false);
+	void GenerateCovers(bool ForceRegeneration = false, bool DoAsync = false);
+
+	// can be called async
+	void AnalizeMeshData(FRecastDebugGeometry& NavMeshGeometry);
 
 	bool MeOcuppying(UCoverPoint* CoverPoint, AController* Controller);
 
@@ -234,10 +240,14 @@ public:
 	TArray<UCoverPoint*> GetCoverWithinBounds(const FBoxCenterAndExtent& BoundsIn);
 	bool CoverExistWithinBounds(const FBoxCenterAndExtent& BoundsIn);
 
-
-
 private:
 
 	UFUNCTION()
 	void OnNavigationGenerationFinished(class ANavigationData* NavData);
+
+	// required by async task:
+public:
+
+	bool bIsRefreshing;
+	bool bIsRefreshed;
 };

--- a/Source/CoverGenerator/Public/GenerateCoversAsync.h
+++ b/Source/CoverGenerator/Public/GenerateCoversAsync.h
@@ -1,0 +1,47 @@
+// Copyright (2017) Ivan Stummer - All rights reserved.
+
+#pragma once
+
+#include "AsyncWork.h"
+#include "Runtime/Engine/Classes/AI/Navigation/NavigationSystem.h"
+//#include "GenerateCoversAsyncTask.generated.h" // NO !
+
+
+class FGenerateCoversAsyncTask : public FNonAbandonableTask
+{
+public:
+
+	friend class FAutoDeleteAsyncTask<FGenerateCoversAsyncTask>;
+
+	// data
+	class ACoverGenerator* CoverGenerator;
+	FRecastDebugGeometry NavMeshGeometry;
+
+	//---
+
+	// constructor
+	FGenerateCoversAsyncTask(ACoverGenerator* TheCoverGenerator, FRecastDebugGeometry& TheNavMeshGeometry)
+	{
+		CoverGenerator = TheCoverGenerator;
+		NavMeshGeometry = TheNavMeshGeometry;
+	}
+
+	// destructor
+	~FGenerateCoversAsyncTask()
+	{
+		CoverGenerator = nullptr;
+	}
+
+	/*This function is needed from the API of the engine.
+	My guess is that it provides necessary information
+	about the thread that we occupy and the progress of our task*/
+	FORCEINLINE TStatId GetStatId() const
+	{
+		RETURN_QUICK_DECLARE_CYCLE_STAT(FGenerateCoversAsyncTask, STATGROUP_ThreadPoolAsyncTasks);
+	}
+
+	//---
+
+	/*This function is executed when we tell our task to execute*/
+	void DoWork();
+};


### PR DESCRIPTION
ACoverGenerator::GenerateCovers() now can be called in both sync and async mode. Async mode results in a smooth runtime update, eliminating the freezes experienced in complex levels, especially in case of frequent navmesh changes.