### PR TITLE
Extend box size down by the value of the param BoxH / 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ Intermediate/*
 
 # Cache files for the editor to use
 DerivedDataCache/*
+
+# OS X
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Cover Generator 
+# Message from fork owner:
+
+I'm doing some changes for this plugin, such as minor fixes and optimizations, more EQS tests, maybe something else. If 
+
+# Cover Generator
 
 The cover generator is a plugin for Unreal Engine 4. 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Message from fork owner:
 
-I'm doing some changes for this plugin, such as minor fixes and optimizations, more EQS tests, maybe something else. If 
+I'm doing some changes for this plugin, such as minor fixes and optimizations, more EQS tests, maybe something else. 
 
 # Cover Generator
 

--- a/Source/CoverGenerator/Private/EnvQuery/Generators/EnvQueryGenerator_CoverFMemory.cpp
+++ b/Source/CoverGenerator/Private/EnvQuery/Generators/EnvQueryGenerator_CoverFMemory.cpp
@@ -14,7 +14,7 @@ UEnvQueryGenerator_CoverFMemory::UEnvQueryGenerator_CoverFMemory(const FObjectIn
 	ItemType = UEnvQueryItemType_Cover::StaticClass();
 	GenerateAround = UEnvQueryContext_Querier::StaticClass();
 	SquareExtent.DefaultValue = 750.f;
-	BoxHeight.DefaultValue = 200.f;
+	BoxHeight.DefaultValue = 400.f;
 }
 
 
@@ -41,7 +41,7 @@ void UEnvQueryGenerator_CoverFMemory::GenerateItems(FEnvQueryInstance& QueryInst
 
 	for (int32 ContextIndex = 0; ContextIndex < ContextLocations.Num(); ContextIndex++)
 	{
-		TArray<UCoverPoint*> Covers = CoverGenerator->GetCoverWithinBounds(FBoxCenterAndExtent(ContextLocations[ContextIndex], FVector(SquareE, SquareE, BoxH)));
+		TArray<UCoverPoint*> Covers = CoverGenerator->GetCoverWithinBounds(FBoxCenterAndExtent(ContextLocations[ContextIndex] - FVector(0.f, 0.f, BoxH / 2), FVector(SquareE, SquareE, BoxH)));
 		QueryInstance.AddItemData<UEnvQueryItemType_Cover>(Covers);
 	}
 }

--- a/Source/CoverGenerator/Private/EnvQuery/Tests/EnvQueryTest_FilterCoverPoints.cpp
+++ b/Source/CoverGenerator/Private/EnvQuery/Tests/EnvQueryTest_FilterCoverPoints.cpp
@@ -1,0 +1,64 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#include "CoverGeneratorPrivatePCH.h"
+#include "EnvQueryTest_FilterCoverPoints.h"
+#include "EnvQueryItemType_Cover.h"
+
+
+UEnvQueryTest_FilterCoverPoints::UEnvQueryTest_FilterCoverPoints(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer)
+{
+	Cost = EEnvTestCost::Low;
+	ValidItemType = UEnvQueryItemType_Cover::StaticClass();
+	SetWorkOnFloatValues(false);
+}
+
+void UEnvQueryTest_FilterCoverPoints::RunTest(FEnvQueryInstance& QueryInstance) const
+{
+	UObject* QueryOwner = QueryInstance.Owner.Get();
+	if (QueryOwner == nullptr)
+	{
+		return;
+	}
+
+	BoolValue.BindData(QueryOwner, QueryInstance.QueryID);
+	bool bWantsValid = BoolValue.GetValue();
+
+	for (FEnvQueryInstance::ItemIterator It(this, QueryInstance); It; ++It)
+	{
+		UCoverPoint* CurrentCoverPoint = UEnvQueryItemType_Cover::GetValue(QueryInstance.RawData.GetData() + QueryInstance.Items[It.GetIndex()].DataOffset);
+
+		bool Uno = false;
+		if (bFrontCoverCrouched)
+		{
+			Uno = CurrentCoverPoint->bFrontCoverCrouched && !CurrentCoverPoint->bLeftCoverStanding && !CurrentCoverPoint->bRightCoverStanding;
+		}
+
+		bool Dos = false;
+		if (bLeftCoverCrouched)
+		{
+			Dos = CurrentCoverPoint->bLeftCoverCrouched && !CurrentCoverPoint->bLeftCoverStanding && !CurrentCoverPoint->bRightCoverStanding;
+		}
+
+		bool Tres = false;
+		if (bRightCoverCrouched)
+		{
+			Tres = CurrentCoverPoint->bRightCoverCrouched && !CurrentCoverPoint->bLeftCoverStanding && !CurrentCoverPoint->bRightCoverStanding;
+		}
+
+		bool Cuatro = false;
+		if (bLeftCoverStanding)
+		{
+			Cuatro = CurrentCoverPoint->bLeftCoverStanding;
+		}
+
+		bool Cinco = false;
+		if (bRightCoverStanding)
+		{
+			Cinco = CurrentCoverPoint->bRightCoverStanding;
+		}
+
+		bool bCoverWithFilter = Uno || Dos || Tres || Cuatro || Cinco;
+		
+		It.SetScore(TestPurpose, FilterType, bCoverWithFilter, bWantsValid);
+	}
+}

--- a/Source/CoverGenerator/Public/EnvQuery/Tests/EnvQueryTest_FilterCoverPoints.h
+++ b/Source/CoverGenerator/Public/EnvQuery/Tests/EnvQueryTest_FilterCoverPoints.h
@@ -1,0 +1,36 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "EnvironmentQuery/EnvQueryTest.h"
+#include "EnvQueryTest_FilterCoverPoints.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class COVERGENERATOR_API UEnvQueryTest_FilterCoverPoints : public UEnvQueryTest
+{
+	GENERATED_UCLASS_BODY()
+
+	//UPROPERTY(EditDefaultsOnly, Category = Filter)
+	//bool bAllFlagsTogether = true;
+
+	UPROPERTY(EditDefaultsOnly, Category = Filter)
+	bool bFrontCoverCrouched;
+
+	UPROPERTY(EditDefaultsOnly, Category = Filter)
+	bool bLeftCoverCrouched;
+
+	UPROPERTY(EditDefaultsOnly, Category = Filter)
+	bool bRightCoverCrouched;
+
+	UPROPERTY(EditDefaultsOnly, Category = Filter)
+	bool bLeftCoverStanding;
+
+	UPROPERTY(EditDefaultsOnly, Category = Filter)
+	bool bRightCoverStanding;
+	
+	virtual void RunTest(FEnvQueryInstance& QueryInstance) const override;
+	
+};


### PR DESCRIPTION
When use default 3d template, bot can't find cover point from second floor, so box size for searching points extended down by half of param.
That's why default value right now is 400 instead of 200.

See attached screenshot to see fixed behaviour.

![2018-07-05 23 06 24](https://user-images.githubusercontent.com/1886223/42345458-10c74728-80a8-11e8-8e91-ba5ffbcce73d.jpg)
