### PR TITLE
Fixed both compilation errors that include upgrade to TOctree2

### DIFF
--- a/Source/CoverGenerator/Private/CoverGenerator.cpp
+++ b/Source/CoverGenerator/Private/CoverGenerator.cpp
@@ -588,17 +588,10 @@ void ACoverGenerator::DrawOctreeBounds()
 
 TArray<FCoverPointOctreeElement> ACoverGenerator::GetOctreeElementsWithinBounds(const FBoxCenterAndExtent& BoundsIn)
 {
-	// Iterating over a region in the Octree and storing the elements
-	int count = 0;
 	TArray<FCoverPointOctreeElement> octreeElements;
+	// Iterating over a region in the Octree and storing the elements
+	CoverPointOctree->FindElementsWithBoundsTest(BoundsIn, [&octreeElements](const FCoverPointOctreeElement& CoverPoint) { octreeElements.Add(CoverPoint); });
 
-	for (FCoverPointOctree::TConstElementBoxIterator<> OctreeIt(*CoverPointOctree, BoundsIn);
-	OctreeIt.HasPendingElements();
-		OctreeIt.Advance())
-	{
-		octreeElements.Add(OctreeIt.GetCurrentElement());
-		count++;
-	}
 	// UE_LOG(LogTemp, Log, TEXT("%d elements in %s"), count, *boundingBoxQuery.Extent.ToString());
 
 	return octreeElements;
@@ -608,21 +601,18 @@ TArray<UCoverPoint*> ACoverGenerator::GetCoverWithinBounds(const FBoxCenterAndEx
 {
 	// Iterating over a region in the octree and storing the elements
 	TArray<UCoverPoint*> Covers;
+	CoverPointOctree->FindElementsWithBoundsTest(BoundsIn, [&Covers](const FCoverPointOctreeElement& CoverPoint) { Covers.Add(CoverPoint.GetOwner()); });
 
-	for (FCoverPointOctree::TConstElementBoxIterator<> OctreeIt(*CoverPointOctree, BoundsIn);
-	OctreeIt.HasPendingElements();
-		OctreeIt.Advance())
-	{
-		Covers.Add(OctreeIt.GetCurrentElement().GetOwner());
-	}
+	// UE_LOG(LogTemp, Log, TEXT("Covers within bounds are(new) %d"), (Covers.Num()) );
 
 	return Covers;
 }
 
 bool ACoverGenerator::CoverExistWithinBounds(const FBoxCenterAndExtent& BoundsIn)
 {
-	FCoverPointOctree::TConstElementBoxIterator<> OctreeIt(*CoverPointOctree, BoundsIn);
-	return OctreeIt.HasPendingElements();
+	bool Result = false;
+	CoverPointOctree->FindFirstElementWithBoundsTest(BoundsIn, [&Result](const FCoverPointOctreeElement& CoverPoint) { Result = true; return true; });
+	return Result;
 }
 
 

--- a/Source/CoverGenerator/Private/EnvQuery/Tests/EnvQueryTest_IsCoverPosition.cpp
+++ b/Source/CoverGenerator/Private/EnvQuery/Tests/EnvQueryTest_IsCoverPosition.cpp
@@ -4,6 +4,7 @@
 #include "EnvironmentQuery/Contexts/EnvQueryContext_Querier.h"
 #include "EnvironmentQuery/Items/EnvQueryItemType_VectorBase.h"
 #include "CollisionQueryParams.h"
+#include "DrawDebugHelpers.h"
 #include "Engine/World.h"
 
 #include "EnvQuery/EnvQueryItemType_Cover.h"
@@ -91,11 +92,9 @@ bool UEnvQueryTest_IsCoverPosition::RunLineTraceTo(const FVector& ItemPos, const
 {
 	FCollisionQueryParams TraceParams(Params);
 
-	if (Debug)
+	if (Debug && World)
 	{
-		const FName TraceTag("MyTraceTag");
-		World->DebugDrawTraceTag = TraceTag;
-		TraceParams.TraceTag = TraceTag;
+		DrawDebugLine(World, ContextPos, ItemPos, FColor::Yellow, false, 5.0f, 1, 3);
 	}
 
 	TraceParams.AddIgnoredActor(ItemActor);

--- a/Source/CoverGenerator/Public/CoverGenerator.h
+++ b/Source/CoverGenerator/Public/CoverGenerator.h
@@ -47,7 +47,7 @@ struct FCoverPointOctreeSemantics
 		return A.CoverPoint == B.CoverPoint;
 	}
 
-	static void SetElementId(const FCoverPointOctreeElement& Element, FOctreeElementId Id)
+	static void SetElementId(const FCoverPointOctreeElement& Element, FOctreeElementId2 Id)
 	{
 	}
 
@@ -57,9 +57,9 @@ struct FCoverPointOctreeSemantics
 	}
 };
 
-typedef TOctree<FCoverPointOctreeElement, FCoverPointOctreeSemantics> FCoverPointOctree;
+typedef TOctree2<FCoverPointOctreeElement, FCoverPointOctreeSemantics> FCoverPointOctree;
 
-UCLASS(showcategories=(Movement, Rendering, "AI|NavMesh"), ClassGroup=Cover)
+UCLASS(showcategories=(Movement, Rendering, "AI|NavMesh"), ClassGroup=Cover, Blueprintable)
 class COVERGENERATOR_API ACoverGenerator : public AInfo
 {
 	GENERATED_UCLASS_BODY()


### PR DESCRIPTION
1. CoverGenerator actor was not visible in the "All Classes" window because AInfo class is not Blueprintable by default (fixed)
2. Plugin can't be compiled for 4.26+ versions because TOctree is deprecated (Fixed)
3. Also fixed a strange compilation error 'DebugDrawTraceTag': is not a member of 'UWorld'. It was changed to DebugLine 